### PR TITLE
Handle non-alphanumeric user ids

### DIFF
--- a/eStreamChat/Scripts/eStreamChat.js
+++ b/eStreamChat/Scripts/eStreamChat.js
@@ -139,11 +139,12 @@ $(function () {
         }
 
         // Set default active tab
-        if (!messengerMode)
+        if (!messengerMode) {
             activePanel = $('#panel-room');
-        else {
-            $('#panel-room').attr('id', 'panel-' + messengerTargetUserId);
-            activePanel = $('#panel-' + messengerTargetUserId);
+        } else {
+            // replace non-alphanumeric characters in the userid
+            $('#panel-room').attr('id', 'panel-' + messengerTargetUserId.replace(/[^\w]/g, '_'));
+            activePanel = $('#panel-' + messengerTargetUserId.replace(/[^\w]/g, '_'));
         }
 
         // Prepare the text formatting buttons
@@ -881,10 +882,12 @@ function getPanelForMessage(message) {
 }
 
 function getPanelByUserId(userId) {
-    if (userId == null)
+    if (userId == null) {
         return $('#panel-room');
-    else
-        return $('#panel-' + userId);
+    } else {
+        // replace non-alphanumeric characters in the userid
+        return $('#panel-' + userId.replace(/[^\w]/g, '_'));
+    }
 }
 
 $.fn.setCursorPosition = function(pos) {


### PR DESCRIPTION
In messenger chat, when a user's id has a character that would cause an html attribute to be invalid, anyone chatting with that user will not be able to see any messages. This occurs because the userid is used to create the id for an element that needs to be retrieved to add messages inside.

This is a pretty hacky fix, so do with it what you will. I'm replacing some non-alphanumeric characters that are actually valid in ids but simplicity's sake, I'm just replacing all of them. Here's the HTML 4 specification for what id attributes are allowed if you wanted to do it a bit better (HTML5 is slightly more permissive):

> ID and NAME tokens must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods (".").

So yeah, simplicity wins.

Using this, there is potential that usernames could be duplicated (probably unlikely) or this code exploited. I would suggest not using the userid to create the id for the panel in the first place, and rather assign a auto generated id for the user when they connect to the chat, generating the id attribute based off that. That is, if assigning an id to this element is even necessary at all.
